### PR TITLE
Add "c" and "cpp" to grammar scopes

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -11,7 +11,7 @@ class ClangdClient extends AutoLanguageClient {
     // atom.config.set('core.debugLSP', true);
     super();
   }
-  getGrammarScopes () { return ['source.c', 'source.cpp']; }
+  getGrammarScopes () { return ['source.c', 'source.cpp', 'c', 'cpp']; }
   getLanguageName () { return 'C'; }
   getServerName () { return 'Clangd'; }
 


### PR DESCRIPTION
In addition to "source.c" and "source.cpp", add "c" and "cpp". This seems to be required for newer versions of Atom.